### PR TITLE
Get file extension based on file content instead of trusting filename.

### DIFF
--- a/app/helpers/files.py
+++ b/app/helpers/files.py
@@ -1,5 +1,7 @@
 import os
+import magic
 import secrets
+import mimetypes
 from app import config
 from werkzeug.security import safe_join
 from werkzeug.utils import secure_filename
@@ -39,7 +41,14 @@ class File:
         """Check if file is allowed, based on `config.ALLOWED_EXTENSIONS`."""
         if not config.ALLOWED_EXTENSIONS:
             return True
-        return self.extension in config.ALLOWED_EXTENSIONS
+
+        # Get file mimetype based on first 2048 bytes
+        mime = magic.from_buffer(self.__file.read(2048), mime=True).lower()
+
+        # Convert mimetype to extension, e.g. application/pdf becomes .pdf
+        guessed_ext = mimetypes.guess_extension(mime)
+
+        return self.extension in config.ALLOWED_EXTENSIONS and guessed_ext in config.ALLOWED_EXTENSIONS
 
     def save(self, save_directory = config.UPLOAD_DIR) -> None:
         """Saves the file to `UPLOAD_DIR`."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask == 1.1.2
 discord-webhook >= 0.13.0
 python-dotenv
 python-magic
-python-magic-bin
+python-magic-bin; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ APScheduler == 3.5.3
 Flask == 1.1.2
 discord-webhook >= 0.13.0
 python-dotenv
+python-magic
+python-magic-bin


### PR DESCRIPTION
Use `python-magic` to determine file extension based on first `2048` bytes of the file, instead of blindly trusting the filename, e.g. `myfile.txt`

