### PR TITLE
Remove unused imports and code.

### DIFF
--- a/app/helpers/discord/embeds.py
+++ b/app/helpers/discord/embeds.py
@@ -1,10 +1,5 @@
-from enum import IntEnum
 from app.helpers.utils import Message, random_hex
 from discord_webhook import DiscordEmbed
-
-class EmbedType(IntEnum):
-    FILE = 0
-    SHORT_URL = 1
 
 class CustomDiscordEmbed(DiscordEmbed):
     def __init__(self, **kwargs):

--- a/app/helpers/discord/webhooks.py
+++ b/app/helpers/discord/webhooks.py
@@ -1,7 +1,6 @@
 import logging
 from requests.exceptions import Timeout
 from discord_webhook import DiscordWebhook
-from app.helpers.discord.embeds import EmbedType, FileEmbed, ShortUrlEmbed
 
 logger = logging.getLogger('discord_webhook')
 

--- a/app/helpers/services.py
+++ b/app/helpers/services.py
@@ -5,7 +5,6 @@ from app.helpers import utils
 from app.helpers.files import File
 from app.helpers.urls import ShortUrl
 from app.helpers.utils import Message
-from app.helpers.discord.webhooks import EmbedType
 
 class FileService:
     @staticmethod


### PR DESCRIPTION
Remove unused imports and code since `CustomDiscordWebhook` no longer creates `DiscordEmbed` instances for `File` and `ShortUrl`.