### PR TITLE
Add unsupported mimetypes when Flask application is created.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,7 +3,7 @@ from flask import Flask
 from werkzeug.exceptions import HTTPException
 
 # local imports
-from app.helpers.utils import response
+from app.helpers.utils import response, add_unsupported_mimetypes
 from app.helpers.discord import CustomDiscordWebhook
 
 discord_webhook = CustomDiscordWebhook()
@@ -19,6 +19,9 @@ def create_app():
 
     # Set discord webhook timeout
     discord_webhook.timeout = app.config.get('DISCORD_WEBHOOK_TIMEOUT')
+
+    # Add unsupported mimetypes to mimetypes module
+    add_unsupported_mimetypes()
 
     # jsonify HTTP errors
     @app.errorhandler(HTTPException)

--- a/app/helpers/main.py
+++ b/app/helpers/main.py
@@ -2,10 +2,10 @@
 import os
 import secrets
 import sqlite3
-import mimetypes
 from contextlib import closing
 from urllib.parse import urlparse
 from functools import cached_property
+from mimetypes import guess_extension
 
 # pip imports
 from magic import from_buffer
@@ -46,10 +46,7 @@ class File:
         """Returns extension using `python-magic` and `mimetypes`."""
         file_bytes = self.__file.read(config.MAGIC_BUFFER_BYTES)
         mime = from_buffer(file_bytes, mime=True).lower()
-
-        self.add_unsupported_mimetypes()
-
-        return mimetypes.guess_extension(mime)
+        return guess_extension(mime)
 
     @cached_property
     def original_filename_root(self):
@@ -103,11 +100,6 @@ class File:
         self.__file.seek(os.SEEK_SET)
 
         self.__file.save(save_path)
-
-    def add_unsupported_mimetypes(self):
-        """Adds unsupported mimetypes/extensions to `mimetypes` module."""
-        mimetypes.add_type('video/x-m4v', '.m4v')
-        mimetypes.add_type('image/webp', '.webp')
 
     def embed(self) -> FileEmbed:
         """Returns FileEmbed instance for this file."""

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -1,6 +1,7 @@
 # standard library imports
 import hmac
 import hashlib
+import mimetypes
 from enum import Enum
 from functools import wraps
 from http import HTTPStatus
@@ -48,6 +49,11 @@ def auth_required(f):
                 abort(HTTPStatus.UNAUTHORIZED)
         return f(*args, **kwargs)
     return decorated_function
+
+def add_unsupported_mimetypes():
+    """Adds unsupported mimetypes/extensions to `mimetypes` module."""
+    mimetypes.add_type('video/x-m4v', '.m4v')
+    mimetypes.add_type('image/webp', '.webp')
 
 class Message(str, Enum):
     # Services


### PR DESCRIPTION
Add unsupported mimetypes to `mimetypes` module when Flask application is created instead of doing it always when `File.extension` is called.