### PR TITLE
Move hardcoded mimetype/extension pairs into .env file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can set these environment variables in [.env_example](https://github.com/vre
 | `FLASK_SECRET` | `str` |  `None` | Secret key for Flask application, see https://flask.palletsprojects.com/en/2.0.x/config/#SECRET_KEY |
 | `UPLOAD_DIR` | `str` | `/app/uploads/` | Path for uploaded files. |
 | `ALLOWED_EXTENSIONS` | `str` | `png;jpg;jpeg;gif;webm;mp4;webp;txt;m4v` | Allowed file extensions separated by semicolon. |
+| `CUSTOM_EXTENSIONS` | `str` | `video/x-m4v=m4v,image/webp=webp` | Additional `mimetype=extension` pairs for Python `mimetypes` module |
 | `UPLOAD_PASSWORD` | `str` | `None` | The password to protect `/api/upload` and `/api/shorten` endpoints. |
 | `DISCORD_WEBHOOKS` | `str` | `None` | Discord webhook URLs separated by semicolon. |
 | `DISCORD_WEBHOOK_TIMEOUT` | `int` | `5` | Timeout for Discord webhook requests in seconds. |

--- a/app/config.py
+++ b/app/config.py
@@ -10,6 +10,9 @@ UPLOAD_DIR = env.str('UPLOAD_DIR', os.path.join(os.getcwd(), 'app', 'uploads'))
 # List of allowed file extensions, defaults to ['png', 'jpg', 'jpeg', 'gif', 'webm', 'mp4', 'webp', 'txt', 'm4v']
 ALLOWED_EXTENSIONS = env.list('ALLOWED_EXTENSIONS', 'png;jpg;jpeg;gif;webm;mp4;webp;txt;m4v', delimiter=';')
 
+# Custom list of additional mimetype/extension pairs
+CUSTOM_EXTENSIONS = env.dict('CUSTOM_EXTENSIONS', 'video/x-m4v=m4v,image/webp=webp')
+
 # Password for file uploads, defaults to None
 UPLOAD_PASSWORD = env.str('UPLOAD_PASSWORD', None)
 

--- a/app/helpers/utils.py
+++ b/app/helpers/utils.py
@@ -50,8 +50,10 @@ def auth_required(f):
 
 def add_unsupported_mimetypes():
     """Adds unsupported mimetypes/extensions to `mimetypes` module."""
-    mimetypes.add_type('video/x-m4v', '.m4v')
-    mimetypes.add_type('image/webp', '.webp')
+    for mime, ext in config.CUSTOM_EXTENSIONS.items():
+        mime = mime.lower().strip()
+        ext = f'.{ext.lower().strip()}'
+        mimetypes.add_type(mime, ext)
 
 def logger_handler() -> RotatingFileHandler:
     """Returns `logging.handlers.RotatingFileHandler` for logging."""


### PR DESCRIPTION
Moved hardcoded mimetype/extension pairs to `.env` file, so code changes are not needed if user wants to add more unsupported extensions to `mimetypes` module.