### PR TITLE
Add default values to dotenv template file.

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,19 +1,32 @@
-FLASK_SECRET
+# Secret key for the application, uncomment and set a value
+# FLASK_SECRET = ""
 
-UPLOAD_DIR
+# Path for uploaded files, uncomment and set value to override default location
+# UPLOAD_DIR = ""
 
-ALLOWED_EXTENSIONS
+# Allowed extensions, separated by semicolon
+ALLOWED_EXTENSIONS = "png;jpg;jpeg;gif;webm;mp4;webp;txt;m4v"
 
-UPLOAD_PASSWORD
+# Custom extension map, <mime>=<extension> format, separated by comma
+CUSTOM_EXTENSIONS = "video/x-m4v=m4v,image/webp=webp"
 
-DISCORD_WEBHOOKS
+# Password for uploading, optional
+UPLOAD_PASSWORD = ""
 
-DISCORD_WEBHOOK_TIMEOUT
+# Discord webhooks, separated by semicolon
+DISCORD_WEBHOOKS = ""
 
-MAGIC_BUFFER_BYTES
+# Timeout for discord webhook request
+DISCORD_WEBHOOK_TIMEOUT = 5
 
-FILE_TOKEN_BYTES
+# The amount of bytes python-magic will read from uploaded file to determine its extension
+MAGIC_BUFFER_BYTES = 2048
 
-URL_TOKEN_BYTES
+# The amount of bytes for secrets.token_urlsafe, used in filenames
+FILE_TOKEN_BYTES = 12
 
-ORIGINAL_FILENAME_LENGTH
+# The amount of bytes for secrets.token_urlsafe, used in shortened URLs
+URL_TOKEN_BYTES = 6
+
+# The amount of characters which will be appended to random filename from original filename
+ORIGINAL_FILENAME_LENGTH = 18

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ ShareX upload config is available at `/api/sharex/upload`.
 7. Setup environment variables:  
 `cd /var/www/shrpy/`  
 `cp .env_template .env`  
-`nano .env` and set `FLASK_SECRET` to secret string, e.g. `FLASK_SECRET="XYZ"`  
+`nano .env` and uncomment `FLASK_SECRET` and set its value to a secret string, e.g. `FLASK_SECRET = "XYZ"`  
 9. Configure supervisor to run gunicorn:  
 `nano /etc/supervisor/conf.d/shrpy.conf`
 ```

--- a/app/config.py
+++ b/app/config.py
@@ -2,35 +2,25 @@ from environs import Env
 from pathlib import Path
 
 env = Env()
-env.read_env()
+env.read_env(override=True)
 
-# Path for uploaded files, defaults to /app/uploads/
-UPLOAD_DIR = env.str('UPLOAD_DIR', f'{Path.cwd()}/app/uploads')
+UPLOAD_DIR = env.path('UPLOAD_DIR', f'{Path.cwd()}/app/uploads')
 
-# List of allowed file extensions, defaults to ['png', 'jpg', 'jpeg', 'gif', 'webm', 'mp4', 'webp', 'txt', 'm4v']
-ALLOWED_EXTENSIONS = env.list('ALLOWED_EXTENSIONS', 'png;jpg;jpeg;gif;webm;mp4;webp;txt;m4v', delimiter=';')
+ALLOWED_EXTENSIONS = env.list('ALLOWED_EXTENSIONS', delimiter=';')
 
-# Custom list of additional mimetype/extension pairs
-CUSTOM_EXTENSIONS = env.dict('CUSTOM_EXTENSIONS', 'video/x-m4v=m4v,image/webp=webp')
+CUSTOM_EXTENSIONS = env.dict('CUSTOM_EXTENSIONS')
 
-# Password for file uploads, defaults to None
-UPLOAD_PASSWORD = env.str('UPLOAD_PASSWORD', None)
+UPLOAD_PASSWORD = env.str('UPLOAD_PASSWORD')
 
-# List of Discord webhooks, defaults to empty list
-DISCORD_WEBHOOKS = env.list('DISCORD_WEBHOOKS', '', delimiter=';')
+DISCORD_WEBHOOKS = env.list('DISCORD_WEBHOOKS', delimiter=';')
 
-# Timeout for discord webhook in seconds, defaults to 5
-DISCORD_WEBHOOK_TIMEOUT = env.int('DISCORD_WEBHOOK_TIMEOUT', 5)
+DISCORD_WEBHOOK_TIMEOUT = env.int('DISCORD_WEBHOOK_TIMEOUT')
 
-# The amount of bytes python-magic will read from uploaded file to determine its extension, defaults to 2048
-MAGIC_BUFFER_BYTES = env.int('MAGIC_BUFFER_BYTES', 2048)
+MAGIC_BUFFER_BYTES = env.int('MAGIC_BUFFER_BYTES')
 
-# The amount of bytes for secrets.token_urlsafe, used in filenames, defaults to 12
-FILE_TOKEN_BYTES = env.int('FILE_TOKEN_BYTES', 12)
+FILE_TOKEN_BYTES = env.int('FILE_TOKEN_BYTES')
 
-# The amount of bytes for secrets.token_urlsafe, used in shortened URLs, defaults to 6
-URL_TOKEN_BYTES = env.int('URL_TOKEN_BYTES', 6)
+URL_TOKEN_BYTES = env.int('URL_TOKEN_BYTES')
 
-# The amount of characters which will be appended to random filename from original filename, defaults to 18
-ORIGINAL_FILENAME_LENGTH = env.int('ORIGINAL_FILENAME_LENGTH', 18)
+ORIGINAL_FILENAME_LENGTH = env.int('ORIGINAL_FILENAME_LENGTH')
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -61,6 +61,10 @@ def logger_handler() -> StreamHandler:
 
 def create_hmac_hash(hmac_payload: str, hmac_secret_key: str) -> str:
     """Returns sha256 HMAC hexdigest."""
+
+    if hmac_secret_key is None:
+        raise RuntimeError('hmac_secret_key cannot be None, please set a secret for the application in dotenv file!')
+
     return new(
         hmac_secret_key.encode('utf-8'),
         hmac_payload.encode('utf-8'),


### PR DESCRIPTION
Added dotenv default values to the template file to counter `environs` default value magic.

This should make it more intuitive to see and modify the environment variable values, without looking into the source code.
