### PR TITLE
Simplify DiscordEmbed instance creation and webhook.

### DIFF
--- a/app/core/discord.py
+++ b/app/core/discord.py
@@ -1,66 +1,53 @@
 # standard library imports
 from random import randint
-from functools import cached_property
 
 # pip imports
-from flask import current_app
 from requests.exceptions import Timeout
 from discord_webhook import DiscordWebhook, DiscordEmbed
+
+# local imports
+import app
 
 class CustomDiscordWebhook(DiscordWebhook):
     def __init__(self, url=None, **kwargs):
         super().__init__(url, **kwargs)
 
-    @cached_property
+    @property
     def is_enabled(self) -> bool:
         """Checks if Discord webhook is enabled."""
         return self.url is not None and len(self.url) > 0
 
-    def execute(self, remove_embeds=True, remove_files=True):
-        """Executes the webhook and handles Timeout exception."""
+    def send_embed(self, embed: DiscordEmbed):
+        """Sends the given DiscordEmbed to webhook."""
         if self.is_enabled is False:
-            return None
+            return
+
+        self.add_embed(embed)
 
         try:
-            return super().execute(remove_embeds, remove_files)
+            return self.execute(True, True)
         except Timeout as err:
-            current_app.logger.error(f'requests.exceptions.Timeout exception has occurred during webhook execution: {err}')
+            app.application_config.logger.error(f'requests.exceptions.Timeout exception has occurred during webhook execution: {err}')
 
-class CustomDiscordEmbed(DiscordEmbed):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+def create_uploaded_file_embed(url: str, deletion_url: str) -> DiscordEmbed:
+    """Creates an instance of DiscordEmbed for uploaded files."""
+    embed = DiscordEmbed()
+    embed.set_title('New file has been uploaded!')
+    embed.set_description(url)
+    embed.set_image(url=url)
+    embed.set_timestamp()
+    embed.set_color(randint(0, 0xffffff))
+    embed.add_embed_field(name='URL', value=f'**[Click here to view]({url})**')
+    embed.add_embed_field(name='Deletion URL', value=f'**[Click here to delete]({deletion_url})**')
+    return embed
 
-        # ShareX file URL/short URL and deletion URL
-        self.content_url = kwargs.get('content_url')
-        self.deletion_url = kwargs.get('deletion_url')
-
-        # Add markdown links to embed
-        self.add_embed_field(name='URL', value=f'**[Click here to view]({self.content_url})**')
-        self.add_embed_field(name='Deletion URL', value=f'**[Click here to delete]({self.deletion_url})**')
-
-        # Set random color for embed
-        self.set_color(
-            randint(0, 0xffffff)
-        )
-
-        self.set_timestamp()
-
-class FileEmbed(CustomDiscordEmbed):
-    def __init__(self, **kwargs):
-        """Represents DiscordEmbed for files."""
-        super().__init__(**kwargs)
-
-        self.set_title('New file has been uploaded!')
-        self.set_description(self.content_url)
-        self.set_image(url=self.content_url)
-
-class ShortUrlEmbed(CustomDiscordEmbed):
-    def __init__(self, **kwargs):
-        """Represents DiscordEmbed for short URLs."""
-        super().__init__(**kwargs)
-
-        self.set_title('URL has been shortened!')
-        self.set_description('{} => {}'.format(
-            kwargs.get('original_url'),
-            kwargs.get('shortened_url')
-        ))
+def create_short_url_embed(original_url: str, shortened_url: str, deletion_url: str) -> DiscordEmbed:
+    """Creates an instance of DiscordEmbed for shortened URLs."""
+    embed = DiscordEmbed()
+    embed.set_title('URL has been shortened!')
+    embed.set_description('{} => {}'.format(original_url, shortened_url))
+    embed.add_embed_field(name='URL', value=f'**[Click here to view]({original_url})**')
+    embed.add_embed_field(name='Deletion URL', value=f'**[Click here to delete]({deletion_url})**')
+    embed.set_color(randint(0, 0xffffff))
+    embed.set_timestamp()
+    return embed


### PR DESCRIPTION
- Moved `DiscordEmbed` instance creation into two different functions `create_uploaded_file_embed` and `create_short_url_embed`
- Added `send_embed` method to `CustomDiscordWebhook`
- Removed `X-Use-Original-Filename` header from ShareX file upload config