### PR TITLE
Fix NameError and remove UploaderConfig dependency from File class.

### DIFF
--- a/app/core/main.py
+++ b/app/core/main.py
@@ -22,14 +22,13 @@ class UploadedFile:
     """Represents uploaded file."""
     filename: str
     extension: str
-    config: UploaderConfig
 
-    def is_allowed(self) -> bool:
-        """Check if file is allowed, based on `config.allowed_extensions`."""
+    def is_allowed(self, allowed_extensions: list) -> bool:
+        """Check if file is allowed, based on `allowed_extensions`."""
         if not self.extension:
             return False
         ext_without_dot = self.extension.replace('.', '')
-        return ext_without_dot in self.config.allowed_extensions
+        return ext_without_dot in allowed_extensions
 
     def generate_filename_hmac(self, secret: str) -> str:
         """Generates HMAC from filename and extension."""
@@ -68,7 +67,7 @@ class UploadedFile:
         mime = from_buffer(file_bytes, mime=True).lower()
         extension = guess_extension(mime)
 
-        return cls(filename, extension, config)
+        return cls(filename, extension)
 
 @dataclass(frozen=True)
 class ShortUrl:

--- a/app/core/services.py
+++ b/app/core/services.py
@@ -29,7 +29,7 @@ class FileService:
         uploaded_file = UploadedFile.from_file_storage_instance(f, uploader_config)
 
         # Check if file is allowed
-        if uploaded_file.is_allowed() is False:
+        if uploaded_file.is_allowed(uploader_config.allowed_extensions) is False:
             abort(HTTPStatus.UNPROCESSABLE_ENTITY, 'Invalid file type.')
 
         # Save the file
@@ -95,7 +95,7 @@ class FileService:
     @staticmethod
     def get_by_filename() -> Response:
         filename = request.view_args.get('filename')
-        return send_from_directory(uploaded_file_config.upload_directory, filename)
+        return send_from_directory(uploader_config.upload_directory, filename)
 
 class ShortUrlService:
     @staticmethod


### PR DESCRIPTION
- Fixed `NameError: name 'uploaded_file_config' is not defined` when attempting to view uploaded file when running on Flask development server.
- Removed `UploaderConfig` instance dependency from `File` class.